### PR TITLE
Create Prettier instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A web based tournament app, that allows users to create tournaments for any spor
 
 ---
 
-## Contributing to the Repo
+## Contributing
 
 ### Forking
 
@@ -22,7 +22,7 @@ If you are not a direct access contributor to this repository, then you will nee
 
 ---
 
-## How to run
+## How To Run
 
 - clone the repo using the steps above.
 - go into the directory `cd HotshotTournaments/`
@@ -31,8 +31,26 @@ If you are not a direct access contributor to this repository, then you will nee
 
 ---
 
-### Using markdown
+## Using Markdown
 
-Any files that have the `.md` suffix required the Markdown syntax to work properly, use this link to for a little [cheatsheet here](https://github.com/adam-p/markdown-here/wiki/Markdown-Here-Cheatsheet)
+Any files that have the `.md` suffix required the Markdown syntax to work properly, use this link to for a little [cheatsheet here](https://guides.github.com/pdfs/markdown-cheatsheet-online.pdf)
 
 Note: If you ever want to make a comment on any of the GitHub textboxes, they all support mardown natively.
+
+---
+
+## Configuring Code Formatting
+
+We use [Prettier](https://prettier.io/) to ensure that all our code adheres to the [JavaScript Standard Style](https://standardjs.com/rules.html). To contribute to the project, you'll have to use Prettier and use the [StandardJS Prettier config](https://www.npmjs.com/package/prettier-config-standard). It doesn't matter what editor you use, but we recommend VScode. To setup Prettier, follow these steps:
+
+1. Run `npm i` to install all the projects dependencies, including [prettier-config-standard](https://www.npmjs.com/package/prettier-config-standard)
+2. Open *settings.json* by launching the Command Palette (<kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>P</kbd> on MacOS or <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> on Windows), type *settings.json* and press <kbd>↵</kbd>
+3. Add the following key:value pairs to set Prettier as the default formatter:
+```json
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+```
+
+No extra configuration is needed; Prettier is already pointing to the configuration file in package.json. Now you should be able to format an entire document by launching the Command Palette and running Format Document (Forced).

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "socket.io": "^4.0.0"
       },
       "devDependencies": {
-        "nodemon": "^2.0.7"
+        "nodemon": "^2.0.7",
+        "prettier": "2.2.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2400,6 +2401,18 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -5076,6 +5089,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "socket.io": "^4.0.0"
   },
   "devDependencies": {
-    "nodemon": "^2.0.7"
+    "nodemon": "^2.0.7",
+    "prettier": "2.2.1"
   }
 }


### PR DESCRIPTION
- Add instructions to README.md
- Add Prettier as a dev dependency
- Update markdown instruction to point to official Github cheetsheet