### PR TITLE
Split my tournaments view

### DIFF
--- a/src/controllers/tournamentsController.js
+++ b/src/controllers/tournamentsController.js
@@ -41,7 +41,9 @@ exports.get_all_users_tournaments = async (req, res) => {
     )
     res.render('tournaments/myTournaments', {
       memberTournaments: memberTournaments,
-      userCreatedTournaments: userCreatedTournaments
+      userCreatedTournaments: userCreatedTournaments,
+      memberTournamentCount: memberTournaments.length,
+      userCreatedTournamentCount: userCreatedTournaments.length
     })
   } catch (error) {
     return handlers.response_handler(

--- a/src/controllers/tournamentsController.js
+++ b/src/controllers/tournamentsController.js
@@ -18,7 +18,6 @@ exports.get_all_users_tournaments = async (req, res) => {
         }
       })
     memberTournaments.forEach((tournament) => {
-      console.log(tournament.creator[0] + '  ' + req.user._id)
       tournament.parsedStartDate = moment(tournament.startDate)
         .utc()
         .local()
@@ -37,7 +36,6 @@ exports.get_all_users_tournaments = async (req, res) => {
     const userCreatedTournaments = memberTournaments.filter(
       (tournament) => String(tournament.creator) === String(req.user._id)
     )
-    console.log(userCreatedTournaments)
     res.render('tournaments/myTournaments', {
       memberTournaments: memberTournaments,
       userCreatedTournaments: userCreatedTournaments

--- a/src/controllers/tournamentsController.js
+++ b/src/controllers/tournamentsController.js
@@ -17,33 +17,31 @@ exports.get_all_users_tournaments = async (req, res) => {
           select: '-_id -__v -password'
         }
       })
-    memberTournaments.forEach(tournament => {
+    memberTournaments.forEach((tournament) => {
       console.log(tournament.creator[0] + '  ' + req.user._id)
-      const parsedStartDate = moment(tournament.startDate)
-      .utc()
-      .local()
-      .format('DD/MM/YY, HH:mm')
+      tournament.parsedStartDate = moment(tournament.startDate)
+        .utc()
+        .local()
+        .format('DD/MM/YY, HH:mm')
 
-      const parsedEndDate = moment(tournament.endDate)
-      .utc()
-      .local()
-      .format('DD/MM/YY, HH:mm')
+      tournament.parsedEndDate = moment(tournament.endDate)
+        .utc()
+        .local()
+        .format('DD/MM/YY, HH:mm')
 
-      const parsedDateCreated = moment(tournament.dateCreated)
-      .utc()
-      .local()
-      .format('DD/MM/YY')
-
-      tournament.parsedStartDate = parsedStartDate
-      tournament.parsedEndDate = parsedEndDate
-      tournament.parsedDateCreated = parsedDateCreated
+      tournament.parsedDateCreated = moment(tournament.dateCreated)
+        .utc()
+        .local()
+        .format('DD/MM/YY')
     })
-    const userCreatedTournaments = memberTournaments.filter(tournament => String(tournament.creator) === String(req.user._id))
+    const userCreatedTournaments = memberTournaments.filter(
+      (tournament) => String(tournament.creator) === String(req.user._id)
+    )
     console.log(userCreatedTournaments)
     res.render('tournaments/myTournaments', {
       memberTournaments: memberTournaments,
       userCreatedTournaments: userCreatedTournaments
-     })
+    })
   } catch (error) {
     return handlers.response_handler(
       '/',
@@ -64,21 +62,23 @@ exports.add_user_to_tournament = async (req, res) => {
       inviteCode: token
     })
 
-    if (!tournament) return handlers.response_handler(
-      '/tournaments/myTournaments',
-      'error_msg',
-      'Tournament not found',
-      req,
-      res
-    )
-    if (tournament.users.includes(req.user._id)) return handlers.response_handler(
-      `/tournaments/${tournamentID}`,
-      'error_msg',
-      'You are already involved with this tournament',
-      req,
-      res
-    )
-  
+    if (!tournament)
+      return handlers.response_handler(
+        '/tournaments/myTournaments',
+        'error_msg',
+        'Tournament not found',
+        req,
+        res
+      )
+    if (tournament.users.includes(req.user._id))
+      return handlers.response_handler(
+        `/tournaments/${tournamentID}`,
+        'error_msg',
+        'You are already involved with this tournament',
+        req,
+        res
+      )
+
     if (tournament.users.length >= tournament.limit) {
       return handlers.response_handler(
         '/tournaments/myTournaments',
@@ -90,13 +90,14 @@ exports.add_user_to_tournament = async (req, res) => {
     }
     const today = new Date()
 
-    if (tournament.endDate < today) return handlers.response_handler(
-      '/tournaments/myTournaments',
-      'error_msg',
-      'Tournament has already ended',
-      req,
-      res
-    )
+    if (tournament.endDate < today)
+      return handlers.response_handler(
+        '/tournaments/myTournaments',
+        'error_msg',
+        'Tournament has already ended',
+        req,
+        res
+      )
     // Add user to the tournament via ID
     tournament.users.push(req.user._id)
     await tournament.save()
@@ -199,23 +200,23 @@ exports.post_create_tournament = async (req, res) => {
       })
       break
 
-      case 'team':
-        newTournament = new Tournament({
-          name: name,
-          description: description,
-          game: game,
-          type: type,
-          bracket: bracket,
-          startDate: new Date(startDate),
-          endDate: new Date(endDate),
-          messages: [],
-          creator: req.user._id,
-          teams: [],
-          users: [req.user._id],
-          inviteCode: token,
-          inviteCodeExpiryDate: new Date(endDate),
-          limit: Number(size)
-        })
+    case 'team':
+      newTournament = new Tournament({
+        name: name,
+        description: description,
+        game: game,
+        type: type,
+        bracket: bracket,
+        startDate: new Date(startDate),
+        endDate: new Date(endDate),
+        messages: [],
+        creator: req.user._id,
+        teams: [],
+        users: [req.user._id],
+        inviteCode: token,
+        inviteCodeExpiryDate: new Date(endDate),
+        limit: Number(size)
+      })
       break
     default:
       req.flash('error_msg', 'Invalid Tournament Type')
@@ -333,7 +334,7 @@ exports.get_one_tournament = async (req, res) => {
     //https://stackoverflow.com/questions/11637353/comparing-mongoose-id-and-strings
     const isTournamentCreator = tournament.creator.equals(req.user._id)
       ? true
-      : false;
+      : false
     //GET THE FULL URL SO IT CAN BE USED IN THE TEXTBOX
     //TODO: FIGURE OUT WHY THIS RENDERS THE URL WITH HTTP NOT HTTPS
     const fullUrl = req.protocol + '://' + req.get('host') + req.originalUrl
@@ -343,7 +344,8 @@ exports.get_one_tournament = async (req, res) => {
       tournamentInviteLink: `${fullUrl}/invite/${tournament.inviteCode}`,
       isTournamentCreator: isTournamentCreator,
       isTeamTournament: tournament.type === 'team' ? true : false,
-      teamsNotEqualsTournamentSize: tournament.teams.length !== tournament.limit ? true : false,
+      teamsNotEqualsTournamentSize:
+        tournament.teams.length !== tournament.limit ? true : false,
       bracketString: JSON.stringify(tournament.bracket)
       /*REASON: Mustache will not allow front-end script to access the properties that are passed from the server
           therefore I'm having to turn the JSON object to a string, then put the string in a <textarea/> element and hide import PropTypes from 'prop-types'
@@ -448,7 +450,7 @@ exports.delete_tournament = async (req, res) => {
 
   //TODO: VALIDATE THAT THIS USER IS THE TOURNAMENT CREATOR
   try {
-    const tournament = await Tournament.findById(tournamentID);
+    const tournament = await Tournament.findById(tournamentID)
     if (!tournament) {
       req.flash('error_msg', 'Could not find tournament')
       return res.redirect('/tournaments/myTournaments')
@@ -458,14 +460,14 @@ exports.delete_tournament = async (req, res) => {
       return res.redirect('/tournaments/myTournaments')
     }
   } catch (error) {
-    console.error(error.message);
+    console.error(error.message)
     req.flash('error_msg', 'Something went wrong please try again later')
     return res.redirect('/tournaments/myTournaments')
   }
-  
+
   try {
     const deletedTournament = await Tournament.deleteOne({
-      _id: tournamentID,
+      _id: tournamentID
     })
     try {
       // Delete all the messages associated with that tournament
@@ -473,7 +475,10 @@ exports.delete_tournament = async (req, res) => {
         tournament: tournamentID
       })
     } catch (error) {
-      console.error('Could not find any messages associated with this tournament',error.message)
+      console.error(
+        'Could not find any messages associated with this tournament',
+        error.message
+      )
       req.flash('error_msg', 'Something went wrong, please try again later')
       return res.redirect('/tournaments/myTournaments')
     }

--- a/src/controllers/tournamentsController.js
+++ b/src/controllers/tournamentsController.js
@@ -6,7 +6,7 @@ const Message = require('../models/Message')
 
 exports.get_all_users_tournaments = async (req, res) => {
   try {
-    const tournaments = await Tournament.find({ users: req.user._id })
+    const memberTournaments = await Tournament.find({ users: req.user._id })
       .populate('users', '-_id -__v -password')
       .populate({
         path: 'messages',
@@ -17,7 +17,8 @@ exports.get_all_users_tournaments = async (req, res) => {
           select: '-_id -__v -password'
         }
       })
-    tournaments.forEach(tournament => {
+    memberTournaments.forEach(tournament => {
+      console.log(tournament.creator[0] + '  ' + req.user._id)
       const parsedStartDate = moment(tournament.startDate)
       .utc()
       .local()
@@ -37,7 +38,12 @@ exports.get_all_users_tournaments = async (req, res) => {
       tournament.parsedEndDate = parsedEndDate
       tournament.parsedDateCreated = parsedDateCreated
     })
-    res.render('tournaments/myTournaments', { tournaments: tournaments })
+    const userCreatedTournaments = memberTournaments.filter(tournament => String(tournament.creator) === String(req.user._id))
+    console.log(userCreatedTournaments)
+    res.render('tournaments/myTournaments', {
+      memberTournaments: memberTournaments,
+      userCreatedTournaments: userCreatedTournaments
+     })
   } catch (error) {
     return handlers.response_handler(
       '/',

--- a/src/controllers/tournamentsController.js
+++ b/src/controllers/tournamentsController.js
@@ -6,7 +6,7 @@ const Message = require('../models/Message')
 
 exports.get_all_users_tournaments = async (req, res) => {
   try {
-    const memberTournaments = await Tournament.find({ users: req.user._id })
+    const allTournaments = await Tournament.find({ users: req.user._id })
       .populate('users', '-_id -__v -password')
       .populate({
         path: 'messages',
@@ -17,7 +17,7 @@ exports.get_all_users_tournaments = async (req, res) => {
           select: '-_id -__v -password'
         }
       })
-    memberTournaments.forEach((tournament) => {
+    allTournaments.forEach((tournament) => {
       tournament.parsedStartDate = moment(tournament.startDate)
         .utc()
         .local()
@@ -33,7 +33,10 @@ exports.get_all_users_tournaments = async (req, res) => {
         .local()
         .format('DD/MM/YY')
     })
-    const userCreatedTournaments = memberTournaments.filter(
+    const memberTournaments = allTournaments.filter(
+      (tournament) => String(tournament.creator) !== String(req.user._id)
+    )
+    const userCreatedTournaments = allTournaments.filter(
       (tournament) => String(tournament.creator) === String(req.user._id)
     )
     res.render('tournaments/myTournaments', {

--- a/src/views/tournaments/myTournaments.mustache
+++ b/src/views/tournaments/myTournaments.mustache
@@ -1,10 +1,10 @@
 {{> partials/head}}
 <body class="d-flex flex-column min-vh-100">
   {{> partials/navbar}}
+  <header class="d-flex align-items-center justify-content-center py-5 border-bottom">
+    <h1 class="text-center">My Tournaments</h1>
+  </header>
   <div class="container">
-    <header class="d-flex align-items-center justify-content-center py-5 border-bottom">
-      <h1 class="text-center">My Tournaments</h1>
-    </header>
     {{> partials/messages}}
     <div class="d-flex justify-content-between border-bottom mt-5">
       <h2>Creator</h2>

--- a/src/views/tournaments/myTournaments.mustache
+++ b/src/views/tournaments/myTournaments.mustache
@@ -6,34 +6,10 @@
       <h1 class="text-center">My Tournaments</h1>
     </header>
     {{> partials/messages}}
+    <h2>Creator</h2>
     <div class="d-flex flex-row justify-content-around align-items-center my-4 flex-wrap">
-      <h2>Creator</h2>
     {{#userCreatedTournaments}}
-      <a class="card bg-light mr-2 text-decoration-none text-muted my-3" style="width: 20rem" href="/tournaments/{{_id}}">
-        <div class="card-header">
-          <div class="d-flex align-items-center justify-content-between card-title">
-            <h3 class="">{{name}}</h3>
-            <span class="badge badge-info small px-1">{{type}}</span>
-          </div>
-          <h5 class="card-text font-italic">
-            {{game}}
-          </h5>
-        </div>
-        <div class="card-body">
-          <div class="d-flex align-items-center justify-content-between card-text">
-            <p class="">Begins</p>
-            <p class="">{{parsedStartDate}}</p>
-          </div>
-          <div class="d-flex align-items-center justify-content-between card-text">
-            <p class="">Ends</p>
-            <p class="">{{parsedEndDate}}</p>
-          </div>
-          <div class="d-flex align-items-center justify-content-between card-text">
-            <p class="">Created</p>
-            <p class="">{{parsedDateCreated}}</p>
-          </div>
-        </div>
-      </a>
+      {{> tournaments/tournamentCard}}
     {{/userCreatedTournaments}}
     {{^userCreatedTournaments}}
       <p class="text-primary">You currently do not have any tournaments. Why not create one?</p>
@@ -42,34 +18,10 @@
 
 
     <!-- This will be a separate view for the tournaments which the user did NOT create -->
+    <h2>Participant</h2>
     <div class="d-flex flex-row justify-content-around align-items-center my-4 flex-wrap">
-      <h2>Participant</h2>
       {{#memberTournaments}}
-        <a class="card bg-light mr-2 text-decoration-none text-muted my-3" style="width: 20rem" href="/tournaments/{{_id}}">
-          <div class="card-header">
-            <div class="d-flex align-items-center justify-content-between card-title">
-              <h3 class="">{{name}}</h3>
-              <span class="badge badge-info small px-1">{{type}}</span>
-            </div>
-            <h5 class="card-text font-italic">
-              {{game}}
-            </h5>
-          </div>
-          <div class="card-body">
-            <div class="d-flex align-items-center justify-content-between card-text">
-              <p class="">Begins</p>
-              <p class="">{{parsedStartDate}}</p>
-            </div>
-            <div class="d-flex align-items-center justify-content-between card-text">
-              <p class="">Ends</p>
-              <p class="">{{parsedEndDate}}</p>
-            </div>
-            <div class="d-flex align-items-center justify-content-between card-text">
-              <p class="">Created</p>
-              <p class="">{{parsedDateCreated}}</p>
-            </div>
-          </div>
-        </a>
+        {{> tournaments/tournamentCard}}
       {{/memberTournaments}}
       {{^memberTournaments}}
         <p class="text-primary">You aren't a part of any other tournaments :(</p>

--- a/src/views/tournaments/myTournaments.mustache
+++ b/src/views/tournaments/myTournaments.mustache
@@ -14,7 +14,6 @@
             <h3 class="">{{name}}</h3>
             <span class="badge badge-info small px-1">{{type}}</span>
           </div>
-          <!-- No need to display the description in the card - that should be reserved for on the main page -->
           <h5 class="card-text font-italic">
             {{game}}
           </h5>
@@ -39,6 +38,41 @@
       <p class="text-primary">You currently do not have any tournaments, why not created one!</p>
     {{/tournaments}}
     </div>
+
+
+    <!-- This will be a separate view for the tournaments which the user did NOT create -->
+    <div class="d-flex flex-row justify-content-around align-items-center my-4 flex-wrap">
+      {{#memberTournaments}}
+        <a class="card bg-light mr-2 text-decoration-none text-muted my-3" style="width: 20rem" href="/tournaments/{{_id}}">
+          <div class="card-header">
+            <div class="d-flex align-items-center justify-content-between card-title">
+              <h3 class="">{{name}}</h3>
+              <span class="badge badge-info small px-1">{{type}}</span>
+            </div>
+            <h5 class="card-text font-italic">
+              {{game}}
+            </h5>
+          </div>
+          <div class="card-body">
+            <div class="d-flex align-items-center justify-content-between card-text">
+              <p class="">Begins</p>
+              <p class="">{{parsedStartDate}}</p>
+            </div>
+            <div class="d-flex align-items-center justify-content-between card-text">
+              <p class="">Ends</p>
+              <p class="">{{parsedEndDate}}</p>
+            </div>
+            <div class="d-flex align-items-center justify-content-between card-text">
+              <p class="">Created</p>
+              <p class="">{{parsedDateCreated}}</p>
+            </div>
+          </div>
+        </a>
+      {{/memberTournaments}}
+      {{^memberTournaments}}
+        <p class="text-primary">You aren't a part of any other tournaments :(</p>
+      {{/memberTournaments}}
+      </div>
   </div>
   {{> partials/footer}}
 </body>

--- a/src/views/tournaments/myTournaments.mustache
+++ b/src/views/tournaments/myTournaments.mustache
@@ -7,7 +7,8 @@
     </header>
     {{> partials/messages}}
     <div class="d-flex flex-row justify-content-around align-items-center my-4 flex-wrap">
-    {{#tournaments}}
+      <h2>Creator</h2>
+    {{#userCreatedTournaments}}
       <a class="card bg-light mr-2 text-decoration-none text-muted my-3" style="width: 20rem" href="/tournaments/{{_id}}">
         <div class="card-header">
           <div class="d-flex align-items-center justify-content-between card-title">
@@ -33,15 +34,16 @@
           </div>
         </div>
       </a>
-    {{/tournaments}}
-    {{^tournaments}}
-      <p class="text-primary">You currently do not have any tournaments, why not created one!</p>
-    {{/tournaments}}
+    {{/userCreatedTournaments}}
+    {{^userCreatedTournaments}}
+      <p class="text-primary">You currently do not have any tournaments. Why not create one?</p>
+    {{/userCreatedTournaments}}
     </div>
 
 
     <!-- This will be a separate view for the tournaments which the user did NOT create -->
     <div class="d-flex flex-row justify-content-around align-items-center my-4 flex-wrap">
+      <h2>Participant</h2>
       {{#memberTournaments}}
         <a class="card bg-light mr-2 text-decoration-none text-muted my-3" style="width: 20rem" href="/tournaments/{{_id}}">
           <div class="card-header">

--- a/src/views/tournaments/myTournaments.mustache
+++ b/src/views/tournaments/myTournaments.mustache
@@ -6,7 +6,10 @@
       <h1 class="text-center">My Tournaments</h1>
     </header>
     {{> partials/messages}}
-    <h2>Creator</h2>
+    <div class="d-flex justify-content-between border-bottom mt-5">
+      <h2>Creator</h2>
+      <h2>{{userCreatedTournamentCount}}</h2>
+    </div>
     <div class="d-flex flex-row justify-content-around align-items-center my-4 flex-wrap">
     {{#userCreatedTournaments}}
       {{> tournaments/tournamentCard}}
@@ -16,9 +19,10 @@
     {{/userCreatedTournaments}}
     </div>
 
-
-    <!-- This will be a separate view for the tournaments which the user did NOT create -->
-    <h2>Participant</h2>
+    <div class="d-flex justify-content-between border-bottom mt-5">
+      <h2>Participant</h2>
+      <h2>{{memberTournamentCount}}</h2>
+    </div>
     <div class="d-flex flex-row justify-content-around align-items-center my-4 flex-wrap">
       {{#memberTournaments}}
         {{> tournaments/tournamentCard}}

--- a/src/views/tournaments/tournamentCard.mustache
+++ b/src/views/tournaments/tournamentCard.mustache
@@ -1,0 +1,25 @@
+<a class="card bg-light mr-2 text-decoration-none text-muted my-3" style="width: 20rem" href="/tournaments/{{_id}}">
+  <div class="card-header">
+    <div class="d-flex align-items-center justify-content-between card-title">
+      <h3 class="">{{name}}</h3>
+      <span class="badge badge-info small px-1">{{type}}</span>
+    </div>
+    <h5 class="card-text font-italic">
+      {{game}}
+    </h5>
+  </div>
+  <div class="card-body">
+    <div class="d-flex align-items-center justify-content-between card-text">
+      <p class="">Begins</p>
+      <p class="">{{parsedStartDate}}</p>
+    </div>
+    <div class="d-flex align-items-center justify-content-between card-text">
+      <p class="">Ends</p>
+      <p class="">{{parsedEndDate}}</p>
+    </div>
+    <div class="d-flex align-items-center justify-content-between card-text">
+      <p class="">Created</p>
+      <p class="">{{parsedDateCreated}}</p>
+    </div>
+  </div>
+</a>


### PR DESCRIPTION
This separates tournaments in the My Tournaments view into two types: those created by the logged in user and those the user is otherwise a member of. Fixes #24.

![image](https://user-images.githubusercontent.com/15250241/112404300-02bb0d80-8d08-11eb-8115-506d5f986958.png)
